### PR TITLE
Support for virtual filesystems through IOSystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea/
+out
+build
+.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,10 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+test {
+	workingDir = "src/test/resources"
+}
+
 artifacts {
     archives sourcesJar
     archives javadocJar

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 
-    switch (OperatingSystem.current()) {
+    /*switch (OperatingSystem.current()) {
         case OperatingSystem.WINDOWS:
             ext.lwjglNatives = "natives-windows"
             break
@@ -54,6 +54,7 @@ dependencies {
             ext.lwjglNatives = "natives-macos"
             break
     }
+
     ext.lwjglVersion = "3.1.5-SNAPSHOT"
     compile "org.lwjgl:lwjgl:${lwjglVersion}"
     compile "org.lwjgl:lwjgl-glfw:${lwjglVersion}"
@@ -66,7 +67,7 @@ dependencies {
     runtime "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:${lwjglNatives}"
     runtime "org.lwjgl:lwjgl-openal:${lwjglVersion}:${lwjglNatives}"
     runtime "org.lwjgl:lwjgl-opengl:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-stb:${lwjglVersion}:${lwjglNatives}"
+    runtime "org.lwjgl:lwjgl-stb:${lwjglVersion}:${lwjglNatives}"*/
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,8 @@ dependencies {
 
     //implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 	implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-
+	testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+	
     switch (OperatingSystem.current()) {
         case OperatingSystem.WINDOWS:
             ext.lwjglNatives = "natives-windows"

--- a/build.gradle
+++ b/build.gradle
@@ -29,21 +29,22 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    compile "org.jetbrains.kotlin:kotlin-reflect"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect"
 
-    compile 'com.github.kotlin-graphics:uno-sdk:641ec79aa3d5cf696590276f75b8b89804dc9d09'
+    implementation 'com.github.kotlin-graphics:uno-sdk:641ec79aa3d5cf696590276f75b8b89804dc9d09'
 
     testCompile 'io.kotlintest:kotlintest:2.0.7'
 
-    compile 'io.github.microutils:kotlin-logging:1.4.6'
+    implementation 'io.github.microutils:kotlin-logging:1.4.6'
 
 //    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.10.0'
 //    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.10.0'
 
-    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+    //implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+	implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
-    /*switch (OperatingSystem.current()) {
+    switch (OperatingSystem.current()) {
         case OperatingSystem.WINDOWS:
             ext.lwjglNatives = "natives-windows"
             break
@@ -56,18 +57,19 @@ dependencies {
     }
 
     ext.lwjglVersion = "3.1.5-SNAPSHOT"
-    compile "org.lwjgl:lwjgl:${lwjglVersion}"
-    compile "org.lwjgl:lwjgl-glfw:${lwjglVersion}"
-    compile "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}"
-    compile "org.lwjgl:lwjgl-openal:${lwjglVersion}"
-    compile "org.lwjgl:lwjgl-opengl:${lwjglVersion}"
-    compile "org.lwjgl:lwjgl-stb:${lwjglVersion}"
-    runtime "org.lwjgl:lwjgl:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-glfw:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-openal:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-opengl:${lwjglVersion}:${lwjglNatives}"
-    runtime "org.lwjgl:lwjgl-stb:${lwjglVersion}:${lwjglNatives}"*/
+    implementation "org.lwjgl:lwjgl:${lwjglVersion}"
+    implementation "org.lwjgl:lwjgl-glfw:${lwjglVersion}"
+    implementation "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}"
+    implementation "org.lwjgl:lwjgl-openal:${lwjglVersion}"
+    implementation "org.lwjgl:lwjgl-opengl:${lwjglVersion}"
+    implementation "org.lwjgl:lwjgl-stb:${lwjglVersion}"
+	
+    testRuntime "org.lwjgl:lwjgl:${lwjglVersion}:${lwjglNatives}"
+    testRuntime "org.lwjgl:lwjgl-glfw:${lwjglVersion}:${lwjglNatives}"
+    testRuntime "org.lwjgl:lwjgl-jemalloc:${lwjglVersion}:${lwjglNatives}"
+    testRuntime "org.lwjgl:lwjgl-openal:${lwjglVersion}:${lwjglNatives}"
+    testRuntime "org.lwjgl:lwjgl-opengl:${lwjglVersion}:${lwjglNatives}"
+    testRuntime "org.lwjgl:lwjgl-stb:${lwjglVersion}:${lwjglNatives}"
 }
 
 repositories {

--- a/src/main/kotlin/assimp/BaseImporter.kt
+++ b/src/main/kotlin/assimp/BaseImporter.kt
@@ -33,7 +33,7 @@ abstract class BaseImporter {
      *  time to examine the contents of the file to be loaded for magic bytes, keywords, etc to be able to load files
      *  with unknown/not existent file extensions.
      *  @return true if the class can read this file, false if not. */
-    abstract fun canRead(file: URI, checkSig: Boolean): Boolean
+    abstract fun canRead(file: String, pIOHandler: IOSystem, checkSig: Boolean): Boolean
 
     /** Imports the given file and returns the imported data.
      *  If the import succeeds, ownership of the data is transferred to the caller. If the import fails, null is
@@ -48,7 +48,7 @@ abstract class BaseImporter {
      *  exception is thrown somewhere in internReadFile(), this function will catch it and transform it into a suitable
      *  response to the caller.
      */
-    fun readFile(imp: Importer, file: URI): AiScene? {
+    fun readFile(imp: Importer, pIOHandler: IOSystem, filePath: String): AiScene? {
         progress = imp.progressHandler
         assert(progress != null)
 
@@ -60,7 +60,7 @@ abstract class BaseImporter {
 
         // dispatch importing
         try {
-            internReadFile(file, sc)
+            internReadFile(filePath, pIOHandler, sc)
         } catch (err: Exception) {
             // extract error description
             err.printStackTrace()
@@ -120,9 +120,9 @@ abstract class BaseImporter {
      *  @param file Path of the file to be imported.
      *  @param scene The scene object to hold the imported data. Null is not a valid parameter.
      *  */
-    open fun internReadFile(file: String, scene: AiScene) = internReadFile(file.uri, scene)
+    open fun internReadFile(file: String, pIOHandler: IOSystem, scene: AiScene) = Unit//internReadFile(file.uri, scene)
 
-    open fun internReadFile(file: URI, scene: AiScene) = Unit
+    //open fun internReadFile(file: URI, pIOHandler: IOSystem, scene: AiScene) = Unit
 
     companion object {
         /** Extract file extension from a string

--- a/src/main/kotlin/assimp/BaseImporter.kt
+++ b/src/main/kotlin/assimp/BaseImporter.kt
@@ -21,6 +21,7 @@ abstract class BaseImporter {
     /** Currently set progress handler. */
     var progress: ProgressHandler? = null
 
+    var ioSystem: IOSystem = ASSIMP.defaultIOSystem
     /** Returns whether the class can handle the format of the given file.
      *.
      *  The implementation should be as quick as possible. A check for the file extension is enough. If no suitable
@@ -48,7 +49,7 @@ abstract class BaseImporter {
      *  exception is thrown somewhere in internReadFile(), this function will catch it and transform it into a suitable
      *  response to the caller.
      */
-    fun readFile(imp: Importer, pIOHandler: IOSystem, filePath: String): AiScene? {
+    fun readFile(imp: Importer, pIOHandler: IOSystem = ioSystem, filePath: String): AiScene? {
         progress = imp.progressHandler
         assert(progress != null)
 
@@ -120,7 +121,7 @@ abstract class BaseImporter {
      *  @param file Path of the file to be imported.
      *  @param scene The scene object to hold the imported data. Null is not a valid parameter.
      *  */
-    open fun internReadFile(file: String, pIOHandler: IOSystem, scene: AiScene) = Unit//internReadFile(file.uri, scene)
+    open fun internReadFile(file: String, pIOHandler: IOSystem = ioSystem, scene: AiScene) = Unit//internReadFile(file.uri, scene)
 
     //open fun internReadFile(file: URI, pIOHandler: IOSystem, scene: AiScene) = Unit
 

--- a/src/main/kotlin/assimp/DefaultIOSystem.kt
+++ b/src/main/kotlin/assimp/DefaultIOSystem.kt
@@ -3,9 +3,9 @@ package assimp
 import java.io.*
 
 class DefaultIOSystem : IOSystem{
-    override fun Exists(pFile: String) = File(pFile).exists()
+    override fun exists(pFile: String) = File(pFile).exists()
 
-    override fun Open(pFile: String): IOStream {
+    override fun open(pFile: String): IOStream {
         var file = File(pFile)
         println(File(".").absolutePath)
         if(!file.exists())

--- a/src/main/kotlin/assimp/DefaultIOSystem.kt
+++ b/src/main/kotlin/assimp/DefaultIOSystem.kt
@@ -1,0 +1,26 @@
+package assimp
+
+import java.io.*
+
+class DefaultIOSystem : IOSystem{
+    override fun Exists(pFile: String) = File(pFile).exists()
+
+    override fun Open(pFile: String): IOStream {
+        var file = File(pFile)
+        println(File(".").absolutePath)
+        if(!file.exists())
+            throw IOException("File doesn't exist")
+
+
+        return FileIOStream(file)
+    }
+
+    class FileIOStream(val file: File) : IOStream{
+        override fun read() = BufferedReader(FileReader(file))
+
+        override val name: String
+            get() = file.absolutePath
+
+        override fun parentPath() = file.parentFile.path
+    }
+}

--- a/src/main/kotlin/assimp/DefaultIOSystem.kt
+++ b/src/main/kotlin/assimp/DefaultIOSystem.kt
@@ -18,9 +18,12 @@ class DefaultIOSystem : IOSystem{
     class FileIOStream(val file: File) : IOStream{
         override fun read() = BufferedReader(FileReader(file))
 
-        override val name: String
+        override val path: String
             get() = file.absolutePath
 
-        override fun parentPath() = file.parentFile.path
+        override val filename: String
+            get() = file.name
+
+        override fun parentPath() = file.parentFile.absolutePath
     }
 }

--- a/src/main/kotlin/assimp/DefaultIOSystem.kt
+++ b/src/main/kotlin/assimp/DefaultIOSystem.kt
@@ -9,14 +9,16 @@ class DefaultIOSystem : IOSystem{
         var file = File(pFile)
         println(File(".").absolutePath)
         if(!file.exists())
-            throw IOException("File doesn't exist")
+            throw IOException("File doesn't exist: "+pFile)
 
 
         return FileIOStream(file)
     }
 
     class FileIOStream(val file: File) : IOStream{
-        override fun read() = BufferedReader(FileReader(file))
+        override fun read() = FileInputStream(file)
+
+        override fun reader() = BufferedReader(FileReader(file))
 
         override val path: String
             get() = file.absolutePath

--- a/src/main/kotlin/assimp/IOStream.kt
+++ b/src/main/kotlin/assimp/IOStream.kt
@@ -1,0 +1,12 @@
+package assimp
+
+import java.io.BufferedReader
+import java.io.Reader
+
+interface IOStream {
+    val name : String
+
+    fun read() : BufferedReader
+
+    fun parentPath() : String
+}

--- a/src/main/kotlin/assimp/IOStream.kt
+++ b/src/main/kotlin/assimp/IOStream.kt
@@ -4,7 +4,9 @@ import java.io.BufferedReader
 import java.io.Reader
 
 interface IOStream {
-    val name : String
+    val path : String
+
+    val filename: String
 
     fun read() : BufferedReader
 

--- a/src/main/kotlin/assimp/IOStream.kt
+++ b/src/main/kotlin/assimp/IOStream.kt
@@ -1,6 +1,7 @@
 package assimp
 
 import java.io.BufferedReader
+import java.io.InputStream
 import java.io.Reader
 
 interface IOStream {
@@ -8,7 +9,9 @@ interface IOStream {
 
     val filename: String
 
-    fun read() : BufferedReader
+    fun read() : InputStream
+
+    fun reader() : BufferedReader
 
     fun parentPath() : String
 }

--- a/src/main/kotlin/assimp/IOSystem.kt
+++ b/src/main/kotlin/assimp/IOSystem.kt
@@ -1,12 +1,14 @@
 package assimp
 
+import java.io.File
+
 /** Interface to the file system. */
 interface IOSystem {
-    fun Exists(pFile: String): Boolean
+    fun exists(pFile: String): Boolean
 
-    fun Open(pFile : String): IOStream
+    fun open(pFile : String): IOStream
 
-    fun Close(ioStream: IOStream) = Unit //unused ?
+    fun close(ioStream: IOStream) = Unit //unused ?
 
-    fun getOsSeperator() = "/"
+    fun getOsSeperator() = File.separator
 }

--- a/src/main/kotlin/assimp/IOSystem.kt
+++ b/src/main/kotlin/assimp/IOSystem.kt
@@ -1,0 +1,12 @@
+package assimp
+
+/** Interface to the file system. */
+interface IOSystem {
+    fun Exists(pFile: String): Boolean
+
+    fun Open(pFile : String): IOStream
+
+    fun Close(ioStream: IOStream) = Unit //unused ?
+
+    fun getOsSeperator() = "/"
+}

--- a/src/main/kotlin/assimp/Importer.kt
+++ b/src/main/kotlin/assimp/Importer.kt
@@ -246,7 +246,9 @@ constructor() {
      * @note Assimp is able to determine the file format of a file automatically.
      */
     //fun readFile(file: URI, flags: Int = 0): AiScene? {
-    fun readFile(file: String, flags: Int = 0): AiScene? {
+    fun readFile(file: String, flags: Int = 0) = readFile(file, ioHandler, flags)
+
+    fun readFile(file: String, ioSystem: IOSystem = this.ioHandler, flags: Int = 0): AiScene? {
 
         writeLogOpening(file)
 

--- a/src/main/kotlin/assimp/ImporterPimpl.kt
+++ b/src/main/kotlin/assimp/ImporterPimpl.kt
@@ -12,6 +12,8 @@ class ImporterPimpl {
     var progressHandler: ProgressHandler = DefaultProgressHandler()
     var isDefaultProgressHandler = true
 
+    var ioSystem: IOSystem = DefaultIOSystem()
+
     /** Format-specific importer worker objects - one for each format we can read.*/
     val importer = importerInstanceList
 

--- a/src/main/kotlin/assimp/assimp.kt
+++ b/src/main/kotlin/assimp/assimp.kt
@@ -55,6 +55,8 @@ val Vec3.isBlack get() = abs(r) < epsilon && abs(g) < epsilon && abs(b) < epsilo
 
 object ASSIMP {
 
+    val defaultIOSystem = DefaultIOSystem()
+
     object BUILD {
 
         var DEBUG = true

--- a/src/main/kotlin/assimp/format/X/XFileImporter.kt
+++ b/src/main/kotlin/assimp/format/X/XFileImporter.kt
@@ -17,14 +17,14 @@ class XFileImporter : BaseImporter() {
 
     var mBuffer: Pointer<Char> = Pointer<Char>(arrayOf())
 
-    override fun canRead(pFile: URI, checkSig: Boolean): Boolean {
+    override fun canRead(pFile: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
         if (!checkSig)   //Check File Extension
-            return pFile.s.substring(pFile.s.lastIndexOf('.') + 1).toLowerCase() == "x"
+            return pFile.substring(pFile.lastIndexOf('.') + 1).toLowerCase() == "x"
         else //Check file Header
             return false
     }
 
-    override fun internReadFile(pFile: URI, pScene: AiScene) {
+    override fun internReadFile(pFile: String, ioSystem: IOSystem, pScene: AiScene) {
         // Read file into memory
         var file = File(pFile)
         if (!file.canRead()) throw FileSystemException(file, null, "Failed to open file \$pFile.")

--- a/src/main/kotlin/assimp/format/assbin/AssbinLoader.kt
+++ b/src/main/kotlin/assimp/format/assbin/AssbinLoader.kt
@@ -23,11 +23,11 @@ class AssbinLoader : BaseImporter() {
     private val be = false // big endian TODO glm global?
 
     override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean) =
-            File(file).inputStream().use { i -> "ASSIMP.binary-dump.".all { it.i == i.read() } }
+            ioSystem.Open(file).read().use { i -> "ASSIMP.binary-dump.".all { it.i == i.read() } }
 
     override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
-        URL(file).openStream().use {
+        ioSystem.Open(file).read().use {
 
             it.skip(44) // signature
 

--- a/src/main/kotlin/assimp/format/assbin/AssbinLoader.kt
+++ b/src/main/kotlin/assimp/format/assbin/AssbinLoader.kt
@@ -8,6 +8,7 @@ import glm_.*
 import java.io.File
 import java.io.InputStream
 import java.net.URI
+import java.net.URL
 
 class AssbinLoader : BaseImporter() {
 
@@ -21,12 +22,12 @@ class AssbinLoader : BaseImporter() {
     var compressed = false
     private val be = false // big endian TODO glm global?
 
-    override fun canRead(file: URI, checkSig: Boolean) =
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean) =
             File(file).inputStream().use { i -> "ASSIMP.binary-dump.".all { it.i == i.read() } }
 
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
-        file.toURL().openStream().use {
+        URL(file).openStream().use {
 
             it.skip(44) // signature
 

--- a/src/main/kotlin/assimp/format/assbin/AssbinLoader.kt
+++ b/src/main/kotlin/assimp/format/assbin/AssbinLoader.kt
@@ -23,11 +23,11 @@ class AssbinLoader : BaseImporter() {
     private val be = false // big endian TODO glm global?
 
     override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean) =
-            ioSystem.Open(file).read().use { i -> "ASSIMP.binary-dump.".all { it.i == i.read() } }
+            ioSystem.open(file).read().use { i -> "ASSIMP.binary-dump.".all { it.i == i.read() } }
 
     override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
-        ioSystem.Open(file).read().use {
+        ioSystem.open(file).read().use {
 
             it.skip(44) // signature
 

--- a/src/main/kotlin/assimp/format/blender/BlenderLoader.kt
+++ b/src/main/kotlin/assimp/format/blender/BlenderLoader.kt
@@ -23,9 +23,9 @@ val tokens = "BLENDER"
 class BlenderImporter : BaseImporter() {
 
     /** Returns whether the class can handle the format of the given file.  */
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
 
-        val extension = file.extension
+        val extension = getExtension(file)
         if (extension == "blend") return true
         else if (extension.isEmpty() || checkSig) {
             TODO()
@@ -46,7 +46,7 @@ class BlenderImporter : BaseImporter() {
                 maxMinor = 50,
                 fileExtensions = listOf("blend"))
 
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
         val fileChannel = RandomAccessFile(File(file), "r").channel
         buffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, fileChannel.size()).order(ByteOrder.nativeOrder())

--- a/src/main/kotlin/assimp/format/blender/BlenderLoader.kt
+++ b/src/main/kotlin/assimp/format/blender/BlenderLoader.kt
@@ -15,7 +15,6 @@ import java.io.FileOutputStream
 import java.io.FileInputStream
 import java.util.zip.GZIPInputStream
 
-
 lateinit var buffer: ByteBuffer
 
 val tokens = "BLENDER"

--- a/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
@@ -517,11 +517,10 @@ class ColladaLoader : BaseImporter() {
 
             // build a temporary array of pointers to the start of each vertex's weights
             val weightStartPerVertex = LongArray(pSrcController.weightCounts.size)
-
             var pit = 0L
             pSrcController.weightCounts.forEachIndexed { i, a ->
-                weightStartPerVertex[a.i] = pit
-                pit += pSrcController.weightCounts[a.i]
+                weightStartPerVertex[i] = pit
+                pit += a
             }
 
             // now for each vertex put the corresponding vertex weights into each bone's weight collection

--- a/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
@@ -87,7 +87,7 @@ class ColladaLoader : BaseImporter() {
     override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
         mFileName = file
         // parse the input file
-        val parser = ColladaParser(ioSystem.Open(file))
+        val parser = ColladaParser(ioSystem.open(file))
         if (parser.mRootNode == null) throw Error("Collada: File came out empty. Something is wrong here.")
         // create the materials first, for the meshes to find
         buildMaterials(parser)

--- a/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
@@ -31,7 +31,7 @@ class ColladaLoader : BaseImporter() {
     }
 
     /** Filename, for a verbose error message */
-    lateinit var mFileName: URI
+    lateinit var mFileName: String
 
     /** Which mesh-material compound was stored under which mesh ID */
     val mMeshIndexByID = mutableMapOf<ColladaMeshIndex, Int>()
@@ -68,10 +68,10 @@ class ColladaLoader : BaseImporter() {
 
     // ------------------------------------------------------------------------------------------------
     // Returns whether the class can handle the format of the given file.
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
 
         // check file extension
-        val extension = file.s.substring(file.s.lastIndexOf('.') + 1).toLowerCase()
+        val extension = file.substring(file.lastIndexOf('.') + 1).toLowerCase()
 
         if (extension == "dae")
             return true
@@ -84,10 +84,10 @@ class ColladaLoader : BaseImporter() {
 
     // ------------------------------------------------------------------------------------------------
     // Imports the given file into the given scene structure.
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
         mFileName = file
         // parse the input file
-        val parser = ColladaParser(file)
+        val parser = ColladaParser(ioSystem.Open(file))
         if (parser.mRootNode == null) throw Error("Collada: File came out empty. Something is wrong here.")
         // create the materials first, for the meshes to find
         buildMaterials(parser)

--- a/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
@@ -516,7 +516,7 @@ class ColladaLoader : BaseImporter() {
             val dstBones = MutableList(numBones, { mutableListOf<AiVertexWeight>() })
 
             // build a temporary array of pointers to the start of each vertex's weights
-            val weightStartPerVertex = ArrayList<Long>()
+            val weightStartPerVertex = LongArray(pSrcController.weightCounts.size)
 
             var pit = 0L
             pSrcController.weightCounts.forEachIndexed { i, a ->
@@ -651,7 +651,8 @@ class ColladaLoader : BaseImporter() {
                         0
                     }
 
-        mat.textures.add(idx, tex)
+        if(idx != -1)
+            mat.textures.add(idx, tex)
     }
 
     /** Fills materials from the collada material definitions   */

--- a/src/main/kotlin/assimp/format/collada/ColladaParser.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaParser.kt
@@ -496,6 +496,7 @@ class ColladaParser(pFile: IOStream) {
                         for (i in 0 until controller.weightCounts.size) {
                             if (i == ints.size) throw Exception("Out of data while reading <vcount>")
                             val int = ints[i]
+                            controller.weightCounts[i] = int.toLong()
                             numWeights += int
                         }
                         testClosing("vcount")

--- a/src/main/kotlin/assimp/format/collada/ColladaParser.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaParser.kt
@@ -117,7 +117,7 @@ class ColladaParser(pFile: IOStream) {
         // generate a XML reader for it
         val factory = XMLInputFactory.newInstance()
 
-        reader = factory.createXMLEventReader(pFile.read())
+        reader = factory.createXMLEventReader(pFile.reader())
 
         // start reading
         readContents()

--- a/src/main/kotlin/assimp/format/collada/ColladaParser.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaParser.kt
@@ -43,7 +43,7 @@ typealias ChannelMap = MutableMap<String, AnimationChannel>
  *  Does all the XML reading and builds data structures from it,
  *  but leaves the resolving of all the references to the loader.
  */
-class ColladaParser(pFile: URI) {
+class ColladaParser(pFile: IOStream) {
 
     /** Filename, for a verbose error message */
     var mFileName = pFile
@@ -93,9 +93,9 @@ class ColladaParser(pFile: URI) {
 
     init {
 
-        val file = File(pFile)
+        //val file = File(pFile)
         // open the file
-        if (!file.exists()) throw Error("Failed to open file: $pFile")
+        //if (!file.exists()) throw Error("Failed to open file: $pFile")
 
 //        val dbFactory = DocumentBuilderFactory.newInstance()
 //        val dBuilder = dbFactory.newDocumentBuilder()
@@ -117,7 +117,7 @@ class ColladaParser(pFile: URI) {
         // generate a XML reader for it
         val factory = XMLInputFactory.newInstance()
 
-        reader = factory.createXMLEventReader(FileReader(file))
+        reader = factory.createXMLEventReader(pFile.read())
 
         // start reading
         readContents()

--- a/src/main/kotlin/assimp/format/fbx/fbxImporter.kt
+++ b/src/main/kotlin/assimp/format/fbx/fbxImporter.kt
@@ -70,9 +70,9 @@ class FbxImporter : BaseImporter() {
 
     val settings = ImportSettings()
 
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
 
-        val extension = file.extension
+        val extension = getExtension(file)
         if (extension == info.fileExtensions[0]) return true
         else if (extension.isEmpty() || checkSig) {
             TODO()
@@ -110,7 +110,7 @@ class FbxImporter : BaseImporter() {
         }
     }
 
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
         val f = File(file)
         if (!f.canRead()) throw Error("Could not open file for reading")

--- a/src/main/kotlin/assimp/format/fbx/fbxMeshGeometry.kt
+++ b/src/main/kotlin/assimp/format/fbx/fbxMeshGeometry.kt
@@ -42,8 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package assimp.format.fbx
 
 import assimp.*
-import glm_.vec2.Vec2
-import org.lwjgl.openal.AL
 import kotlin.reflect.KMutableProperty0
 
 /** @file  FBXImporter.h

--- a/src/main/kotlin/assimp/format/md2/Md2Loader.kt
+++ b/src/main/kotlin/assimp/format/md2/Md2Loader.kt
@@ -73,8 +73,8 @@ class Md2Importer : BaseImporter() {
 
     /** Returns whether the class can handle the format of the given file.
      *  See BaseImporter.canRead() for details. */
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
-        val extension = file.extension
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
+        val extension = getExtension(file)
         if (extension == "md2") return true
 
         // if check for extension is not enough, check for the magic tokens
@@ -107,7 +107,7 @@ class Md2Importer : BaseImporter() {
 
     /** Imports the given file into the given scene structure.
      *  See BaseImporter.internReadFile() for details     */
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
         val file = File(file)
 

--- a/src/main/kotlin/assimp/format/md3/Md3Loader.kt
+++ b/src/main/kotlin/assimp/format/md3/Md3Loader.kt
@@ -338,8 +338,8 @@ class Md3Importer : BaseImporter() {
 
     /** Returns whether the class can handle the format of the given file.
      * See BaseImporter.canRead() for details.  */
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
-        val extension = file.extension
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
+        val extension = getExtension(file)
         if (extension == "md3") return true
         // if check for extension is not enough, check for the magic tokens
         if (extension.isNotEmpty() || checkSig) {
@@ -378,9 +378,9 @@ class Md3Importer : BaseImporter() {
 
     /** Imports the given file into the given scene structure.
      *  See BaseImporter.internReadFile() for details     */
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
-        this.file = file.path
+        this.file = file
         this.scene = scene
 
         // get base path and file name

--- a/src/main/kotlin/assimp/format/md5/MD5Loader.kt
+++ b/src/main/kotlin/assimp/format/md5/MD5Loader.kt
@@ -161,11 +161,11 @@ class Md5Importer : BaseImporter() {
             logger.warn { "Failed to access MD5MESH file: $file" }
             return
         }
-        loadFileIntoMemory(ioFile.read())
+        loadFileIntoMemory(ioFile.reader())
         hadMD5Mesh = true
 
         // now construct a parser and parse the file
-        val parser = MD5Parser(buffer, fileSize)
+        val parser = MD5Parser(buffer)
 
         // load the mesh information from it
         val meshParser = MD5MeshParser(parser.sections)
@@ -330,10 +330,10 @@ class Md5Importer : BaseImporter() {
             logger.warn { "Failed to access MD5ANIM file: $file" }
             return
         }
-        loadFileIntoMemory(ioFile.read())
+        loadFileIntoMemory(ioFile.reader())
 
         // parse the basic file structure
-        val parser = MD5Parser(buffer, fileSize)
+        val parser = MD5Parser(buffer)
         TODO()
         // load the animation information from the parse tree
 //        val animParser = MD5AnimParser (parser.sections)

--- a/src/main/kotlin/assimp/format/md5/MD5Loader.kt
+++ b/src/main/kotlin/assimp/format/md5/MD5Loader.kt
@@ -46,8 +46,11 @@ import assimp.format.AiConfig
 import glm_.detail.Random.int
 import glm_.i
 import uno.buffer.destroy
+import java.io.BufferedReader
 import java.io.File
+import java.io.IOException
 import java.net.URI
+import java.nio.Buffer
 import java.nio.ByteBuffer
 import kotlin.math.sqrt
 
@@ -76,8 +79,8 @@ class Md5Importer : BaseImporter() {
     /** configuration option: prevent anim autoload */
     var configNoAutoLoad = false
 
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
-        val extension = file.extension
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
+        val extension = getExtension(file)
         if (extension == "md5anim" || extension == "md5mesh" || extension == "md5camera") return true
         else if (extension.isNotEmpty() || checkSig) {
 //            TODO() silented to pass tests
@@ -105,29 +108,29 @@ class Md5Importer : BaseImporter() {
 
     /** Imports the given file into the given scene structure.
      *  See BaseImporter::internReadFile() for details     */
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
         this.scene = scene
         hadMD5Mesh = false // TODO remove?
         hadMD5Anim = false
         hadMD5Camera = false
 
-        // remove the file extension
-        val pos = file.path.lastIndexOf('.')
-        this.file = if (pos == -1) file.path else file.path.substring(0, pos + 1)
+        val extension = getExtension(file)
 
-        val extension = file.extension
+        // remove the file extension
+        val pos = file.lastIndexOf('.')
+        this.file = if (pos == -1) file else file.substring(0, pos + 1)
 
         try {
-            if (extension == "md5camera") loadMD5CameraFile()
+            if (extension == "md5camera") loadMD5CameraFile(ioSystem)
             else if (configNoAutoLoad || extension == "md5anim") {
                 // determine file extension and process just *one* file
                 if (extension.isEmpty()) throw Error("Failure, need file extension to determine MD5 part type")
-                if (extension == "md5anim") loadMD5AnimFile()
-                else if (extension == "md5mesh") loadMD5MeshFile()
+                if (extension == "md5anim") loadMD5AnimFile(ioSystem)
+                else if (extension == "md5mesh") loadMD5MeshFile(ioSystem)
             } else {
-                loadMD5MeshFile()
-                loadMD5AnimFile()
+                loadMD5MeshFile(ioSystem)
+                loadMD5AnimFile(ioSystem)
             }
         } catch (exc: Exception) { // std::exception, Assimp::DeadlyImportError
             unloadFileFromMemory()
@@ -148,16 +151,18 @@ class Md5Importer : BaseImporter() {
     }
 
     /** Load a *.MD5MESH file.     */
-    fun loadMD5MeshFile() {
-        val file = File(file + "md5mesh")
-
-        // Check whether we can read from the file
-        if (!file.exists() || !file.canRead() || file.length() == 0L) {
+    fun loadMD5MeshFile(ioSystem: IOSystem) {
+        //val file = File(file + "md5mesh")
+        val ioFile : IOStream
+        try {
+            ioFile = ioSystem.Open(file + "md5mesh")
+        } catch(e : IOException) {
+            // Check whether we can read from the file
             logger.warn { "Failed to access MD5MESH file: $file" }
             return
         }
+        loadFileIntoMemory(ioFile.read())
         hadMD5Mesh = true
-        loadFileIntoMemory(file)
 
         // now construct a parser and parse the file
         val parser = MD5Parser(buffer, fileSize)
@@ -316,16 +321,16 @@ class Md5Importer : BaseImporter() {
     }
 
     /** Load a *.MD5ANIM file.     */
-    fun loadMD5AnimFile() {
-        val file = file + "md5anim"
-        val f = File(file)
-
-        // Check whether we can read from the file
-        if (!f.exists() || !f.canRead() || f.length() == 0L) {
-            logger.warn { "Failed to read MD5ANIM file: $file" }
+    fun loadMD5AnimFile(ioSystem: IOSystem) {
+        val ioFile : IOStream
+        try {
+            ioFile = ioSystem.Open(file + "md5anim")
+        } catch(e : IOException) {
+            // Check whether we can read from the file
+            logger.warn { "Failed to access MD5ANIM file: $file" }
             return
         }
-        loadFileIntoMemory(f)
+        loadFileIntoMemory(ioFile.read())
 
         // parse the basic file structure
         val parser = MD5Parser(buffer, fileSize)
@@ -426,7 +431,7 @@ class Md5Importer : BaseImporter() {
     }
 
     /** Load a *.MD5CAMERA file.     */
-    fun loadMD5CameraFile(): Nothing = TODO()
+    fun loadMD5CameraFile(ioSystem: IOSystem): Nothing = TODO()
 
     /** Construct node hierarchy from a given MD5ANIM
      *  @param iParentID Current parent ID
@@ -515,12 +520,12 @@ class Md5Importer : BaseImporter() {
      *  mBuffer is modified to point to this buffer.
      *  @param pFile File stream to be read
      */
-    fun loadFileIntoMemory(file: File) {
+    fun loadFileIntoMemory(file: BufferedReader) {
         // unload the previous buffer, if any
         unloadFileFromMemory()
 
-        fileSize = file.length().i
-        assert(fileSize != 0)
+        //fileSize = file.length().i
+        //assert(fileSize != 0)
 
         // allocate storage and copy the contents of the file to a memory buffer
         file.readLines()

--- a/src/main/kotlin/assimp/format/md5/MD5Loader.kt
+++ b/src/main/kotlin/assimp/format/md5/MD5Loader.kt
@@ -155,7 +155,7 @@ class Md5Importer : BaseImporter() {
         //val file = File(file + "md5mesh")
         val ioFile : IOStream
         try {
-            ioFile = ioSystem.Open(file + "md5mesh")
+            ioFile = ioSystem.open(file + "md5mesh")
         } catch(e : IOException) {
             // Check whether we can read from the file
             logger.warn { "Failed to access MD5MESH file: $file" }
@@ -324,7 +324,7 @@ class Md5Importer : BaseImporter() {
     fun loadMD5AnimFile(ioSystem: IOSystem) {
         val ioFile : IOStream
         try {
-            ioFile = ioSystem.Open(file + "md5anim")
+            ioFile = ioSystem.open(file + "md5anim")
         } catch(e : IOException) {
             // Check whether we can read from the file
             logger.warn { "Failed to access MD5ANIM file: $file" }

--- a/src/main/kotlin/assimp/format/md5/MD5Parser.kt
+++ b/src/main/kotlin/assimp/format/md5/MD5Parser.kt
@@ -286,7 +286,7 @@ class MD5CameraParser {
 }
 
 /** Parses the block structure of MD5MESH and MD5ANIM files (but does no further processing) */
-class MD5Parser(val lines: ArrayList<String>, val fileSize: Int) {
+class MD5Parser(val lines: ArrayList<String>) {
 
     var lineNumber = 0
     var line = ""
@@ -294,7 +294,7 @@ class MD5Parser(val lines: ArrayList<String>, val fileSize: Int) {
     val sections = ArrayList<Section>()
 
     init {
-        assert(lines.isNotEmpty() && 0 != fileSize)
+        assert(lines.isNotEmpty())
         logger.debug { "MD5Parser begin" }
         // parse the file header
         parseHeader()

--- a/src/main/kotlin/assimp/format/obj/ObjFileImporter.kt
+++ b/src/main/kotlin/assimp/format/obj/ObjFileImporter.kt
@@ -2,9 +2,7 @@ package assimp.format.obj
 
 import assimp.*
 import gli_.gli
-import java.io.File
 import java.io.IOException
-import java.net.URI
 
 /**
  * Created by elect on 21/11/2016.
@@ -37,7 +35,7 @@ class ObjFileImporter : BaseImporter() {
 
         // Read file into memory
         this.file = file//File(file)
-        if (!ioSystem.Exists(file)) throw IOException("Failed to open file $file.")
+        if (!ioSystem.exists(file)) throw IOException("Failed to open file $file.")
 
         // Get the file-size and validate it, throwing an exception when fails
         //val fileSize = this.file.length()
@@ -45,7 +43,7 @@ class ObjFileImporter : BaseImporter() {
         //if (fileSize < ObjMinSize) throw Error("OBJ-file is too small.")
 
         // parse the file into a temporary representation
-        val parser = ObjFileParser(ioSystem.Open(file), ioSystem)
+        val parser = ObjFileParser(ioSystem.open(file), ioSystem)
 
         // And create the proper return structures out of it
         createDataFromImport(parser.m_pModel, scene, ioSystem)
@@ -408,7 +406,7 @@ class ObjFileImporter : BaseImporter() {
     }
 
     /**  Load textures   */
-    fun loadTextures(scene: AiScene, ioSystem: IOSystem) {
+    fun loadTextures(scene: AiScene, ioSystem: IOSystem = this.ioSystem) {
 
         scene.materials.forEach { mtl ->
 
@@ -427,7 +425,7 @@ class ObjFileImporter : BaseImporter() {
                         //to match files even where case is mangled
 
                         val dios = ioSystem as DefaultIOSystem
-                        val actualFile = (dios.Open(file) as DefaultIOSystem.FileIOStream).file
+                        val actualFile = (dios.open(file) as DefaultIOSystem.FileIOStream).file
 
                         if (actualFile.parentFile.listFiles().any { it.name == cleaned }) {
 

--- a/src/main/kotlin/assimp/format/obj/ObjFileImporter.kt
+++ b/src/main/kotlin/assimp/format/obj/ObjFileImporter.kt
@@ -21,31 +21,31 @@ class ObjFileImporter : BaseImporter() {
             fileExtensions = listOf("obj"))
 
     /**  Returns true, if file is an obj file.  */
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
 
         if (!checkSig)   //Check File Extension
-            return file.s.substring(file.s.lastIndexOf('.') + 1) == "obj"
+            return file.substring(file.lastIndexOf('.') + 1) == "obj"
         else //Check file Header
             return false
     }
 
     //  reference to load textures later
-    private lateinit var file: File
+    private lateinit var file: String
 
     /** Obj-file import implementation  */
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
         // Read file into memory
-        this.file = File(file)
-        if (!this.file.canRead()) throw IOException("Failed to open file $file.")
+        this.file = file//File(file)
+        if (!ioSystem.Exists(file)) throw IOException("Failed to open file $file.")
 
         // Get the file-size and validate it, throwing an exception when fails
-        val fileSize = this.file.length()
+        //val fileSize = this.file.length()
 
-        if (fileSize < ObjMinSize) throw Error("OBJ-file is too small.")
+        //if (fileSize < ObjMinSize) throw Error("OBJ-file is too small.")
 
         // parse the file into a temporary representation
-        val parser = ObjFileParser(this.file)
+        val parser = ObjFileParser(ioSystem.Open(file), ioSystem)
 
         // And create the proper return structures out of it
         createDataFromImport(parser.m_pModel, scene)
@@ -409,7 +409,8 @@ class ObjFileImporter : BaseImporter() {
 
     /**  Load textures   */
     fun loadTextures(scene: AiScene) {
-
+        TODO()
+        /*
         scene.materials.forEach { mtl ->
 
             mtl.textures.forEach { tex ->
@@ -440,7 +441,7 @@ class ObjFileImporter : BaseImporter() {
                     logger.warn { "OBJ/MTL: Scene contains  --> " + name  + " already"}
                 }
             }
-        }
+        }*/
     }
 }
 

--- a/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
+++ b/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
@@ -14,7 +14,7 @@ import assimp.AiPrimitiveType as Pt
 val DEFAULT_MATERIAL = AI_DEFAULT_MATERIAL_NAME
 val DefaultObjName = "defaultobject"
 
-class ObjFileParser(private val file: File) {
+class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
 
     //! Pointer to model instance
     val m_pModel = Model()
@@ -30,12 +30,7 @@ class ObjFileParser(private val file: File) {
 
         // Start parsing the file
 
-        //parseFile(file.readLines())
-        BufferedReader(file.bufferedReader()).use {
-            parseFile(it)
-        }
-
-
+        parseFile(file.read())
     }
 
     // -------------------------------------------------------------------
@@ -263,9 +258,9 @@ class ObjFileParser(private val file: File) {
         // get the name of the mat file with spaces
         var filename = ObjTools.getNameWithSpace(words,1)
 
-        val pFile = file.parentFile + filename
+        val pFile = file.parentPath() + filename
 
-        if (!pFile.exists()) {
+        if (!ioSystem.Exists(pFile)) {
             System.err.println("OBJ: Unable to locate material file $filename")
             val strMatFallbackName = filename.substring(0, filename.length - 3) + "mtl"
             println("OBJ: Opening fallback material file $strMatFallbackName")
@@ -277,7 +272,7 @@ class ObjFileParser(private val file: File) {
 
         // Import material library data from file.
         // Some exporters (e.g. Silo) will happily write out empty material files if the model doesn't use any materials, so we allow that.
-        val buffer = pFile.readLines().filter(String::isNotBlank)
+        val buffer = pFile.reader().readLines().filter(String::isNotBlank)
 
         ObjFileMtlImporter(buffer, m_pModel)
     }

--- a/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
+++ b/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
@@ -21,7 +21,7 @@ class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
 
     init {
         // Create the model instance to store all the data
-        m_pModel.m_ModelName = file.name
+        m_pModel.m_ModelName = file.filename
 
         // create default material and store it
         m_pModel.m_pDefaultMaterial = Material(DEFAULT_MATERIAL)
@@ -258,7 +258,8 @@ class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
         // get the name of the mat file with spaces
         var filename = ObjTools.getNameWithSpace(words,1)
 
-        val pFile = file.parentPath() + filename
+        val pFile = file.parentPath() + "/" + filename //windows can just suck it
+        println(pFile)
 
         if (!ioSystem.Exists(pFile)) {
             System.err.println("OBJ: Unable to locate material file $filename")
@@ -272,7 +273,7 @@ class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
 
         // Import material library data from file.
         // Some exporters (e.g. Silo) will happily write out empty material files if the model doesn't use any materials, so we allow that.
-        val buffer = pFile.reader().readLines().filter(String::isNotBlank)
+        val buffer = ioSystem.Open(pFile).read().readLines().filter(String::isNotBlank)
 
         ObjFileMtlImporter(buffer, m_pModel)
     }

--- a/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
+++ b/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
@@ -261,7 +261,7 @@ class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
         val pFile = file.parentPath() + "/" + filename //windows can just suck it
         println(pFile)
 
-        if (!ioSystem.Exists(pFile)) {
+        if (!ioSystem.exists(pFile)) {
             System.err.println("OBJ: Unable to locate material file $filename")
             val strMatFallbackName = filename.substring(0, filename.length - 3) + "mtl"
             println("OBJ: Opening fallback material file $strMatFallbackName")
@@ -273,7 +273,7 @@ class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
 
         // Import material library data from file.
         // Some exporters (e.g. Silo) will happily write out empty material files if the model doesn't use any materials, so we allow that.
-        val buffer = ioSystem.Open(pFile).reader().readLines().filter(String::isNotBlank)
+        val buffer = ioSystem.open(pFile).reader().readLines().filter(String::isNotBlank)
 
         ObjFileMtlImporter(buffer, m_pModel)
     }

--- a/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
+++ b/src/main/kotlin/assimp/format/obj/ObjFileParser.kt
@@ -30,7 +30,7 @@ class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
 
         // Start parsing the file
 
-        parseFile(file.read())
+        parseFile(file.reader())
     }
 
     // -------------------------------------------------------------------
@@ -273,7 +273,7 @@ class ObjFileParser(private val file: IOStream, val ioSystem: IOSystem) {
 
         // Import material library data from file.
         // Some exporters (e.g. Silo) will happily write out empty material files if the model doesn't use any materials, so we allow that.
-        val buffer = ioSystem.Open(pFile).read().readLines().filter(String::isNotBlank)
+        val buffer = ioSystem.Open(pFile).reader().readLines().filter(String::isNotBlank)
 
         ObjFileMtlImporter(buffer, m_pModel)
     }

--- a/src/main/kotlin/assimp/format/ply/PlyLoader.kt
+++ b/src/main/kotlin/assimp/format/ply/PlyLoader.kt
@@ -26,9 +26,9 @@ class PlyLoader : BaseImporter() {
 
     // ------------------------------------------------------------------------------------------------
     // Returns whether the class can handle the format of the given file.
-    override fun canRead(file: URI, checkSig: Boolean): Boolean {
+    override fun canRead(file: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
 
-        val extension = file.s.substring(file.s.lastIndexOf('.') + 1)
+        val extension = file.substring(file.lastIndexOf('.') + 1)
 
         if (extension == "ply")
             return true
@@ -38,7 +38,7 @@ class PlyLoader : BaseImporter() {
 
     // ------------------------------------------------------------------------------------------------
     // Imports the given file into the given scene structure.
-    override fun internReadFile(file: URI, scene: AiScene) {
+    override fun internReadFile(file: String, ioSystem: IOSystem, scene: AiScene) {
 
         val file = File(file)
 

--- a/src/main/kotlin/assimp/format/stl/STLLoader.kt
+++ b/src/main/kotlin/assimp/format/stl/STLLoader.kt
@@ -79,9 +79,9 @@ class StlImporter : BaseImporter() {
 
     // ------------------------------------------------------------------------------------------------
     // Returns whether the class can handle the format of the given file.
-    override fun canRead(pFile: URI, checkSig: Boolean): Boolean {
+    override fun canRead(pFile: String, ioSystem: IOSystem, checkSig: Boolean): Boolean {
 
-        val extension = pFile.s.substring(pFile.s.lastIndexOf('.') + 1)
+        val extension = pFile.substring(pFile.lastIndexOf('.') + 1)
 
         if (extension == "stl") {
             return true
@@ -100,7 +100,7 @@ class StlImporter : BaseImporter() {
 
     // ------------------------------------------------------------------------------------------------
     // Imports the given file into the given scene structure.
-    override fun internReadFile(pFile: URI, scene: AiScene) {
+    override fun internReadFile(pFile: String, ioSystem: IOSystem, scene: AiScene) {
 
         val file = File(pFile)
 

--- a/src/main/kotlin/assimp/settings.kt
+++ b/src/main/kotlin/assimp/settings.kt
@@ -5,4 +5,4 @@ package assimp
  */
 
 
-var ASSIMP_LOAD_TEXTURES = false //don't want that actually
+var ASSIMP_LOAD_TEXTURES = true

--- a/src/main/kotlin/assimp/settings.kt
+++ b/src/main/kotlin/assimp/settings.kt
@@ -5,4 +5,4 @@ package assimp
  */
 
 
-var ASSIMP_LOAD_TEXTURES = true
+var ASSIMP_LOAD_TEXTURES = false //don't want that actually


### PR DESCRIPTION
First, a disclaimer: I'm a complete Kotlin noob and I'm learning as I go.

I have a Java project that requires a good way to load in models, and LWJGL's assimp bindings are kind of bare, and any tweaking to assimp itself would require doing C++ *and* a custom build of LWJGL, so I can't be bothered. This seems like a better option, but there was a lack of the IOSystem interface from the original library that allows for custom filesystems ( implements Open/Close read/seek/write functionality ).

I've went ahead and added that, along with a default implementation that just uses regular File[s]. I've also modified a few importers to make use of them, but haven't yet implemented those who need random access instead of an InputStream/BufferedReader. Tests all run fine, even whose who weren't working in the master revision for some reason, even though I didn't touch that.

I've also fixed two issues with the Collada loader that would not parse files with vertex weights ( or at least, wouldn't parse mine ). The first issue was related to an ArrayList being indexed but not initialized with any capacity, I fixed it by changing it into a LongArray. The second one was a -1 access when disabling ASSIMP_LOAD_TEXTURES ( a feature the cpp version doesn't have and I really need )

Finally, I must ask whether it is planned to drop the requirement from having LWJGL in this library's path. It's potentially causing conflicts with other version of LWJGL, and generally unwanted (the original assimp has no such dependencies). It's something that would make this library much more clean, at least in my eyes.