### PR TITLE
loadFileFromMemory implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,9 +82,10 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-//test {
+test {
 //	workingDir = "src/test/resources"
-//}
+    useJUnitPlatform()
+}
 
 artifacts {
     archives sourcesJar

--- a/src/main/kotlin/assimp/IOStream.kt
+++ b/src/main/kotlin/assimp/IOStream.kt
@@ -6,7 +6,7 @@ import java.nio.file.Path
 
 interface IOStream {
 
-    val path : Path
+    val path : Path?
 
     val filename: String
 

--- a/src/main/kotlin/assimp/Importer.kt
+++ b/src/main/kotlin/assimp/Importer.kt
@@ -189,7 +189,13 @@ constructor() {
     var ioHandler: IOSystem
         get() = impl.ioSystem
         set(value) {
-            if (value != null) impl.ioSystem = value
+            if (value != null) {
+                impl.ioSystem = value
+                impl.isDefaultHandler = false
+            } else {
+                impl.ioSystem = DefaultIOSystem()
+                impl.isDefaultHandler = true
+            }
         }
 
     /** Checks whether a default progress handler is active
@@ -375,16 +381,18 @@ constructor() {
             impl.errorString = "Invalid parameters passed to ReadFileFromMemory()"
             return null
         }
-        TODO()
-        // read the file and recover the previous IOSystem
-//        static const size_t BufferSize(Importer::MaxLenHint + 28);
-//        char fbuff[ BufferSize ];
-//        ai_snprintf(fbuff, BufferSize, "%s.%s",AI_MEMORYIO_MAGIC_FILENAME,pHint);
-//        ReadFile(fbuff, pFlags)
-//        SetIOHandler(io)
-//
-//        ASSIMP_END_EXCEPTION_REGION(const aiScene *)
-//        return pimpl->mScene
+
+        // prevent deletion of previous IOSystem
+        val io = impl.ioSystem
+
+        ioHandler = MemoryIOSystem(buffer)
+
+        val fileName = "$AI_MEMORYIO_MAGIC_FILENAME.$hint"
+        readFile(fileName, flags)
+
+        impl.ioSystem = io
+
+        return impl.scene
     }
 
     /** Apply post-processing to an already-imported scene.

--- a/src/main/kotlin/assimp/MemoryIOWrapper.kt
+++ b/src/main/kotlin/assimp/MemoryIOWrapper.kt
@@ -1,0 +1,137 @@
+package assimp
+
+import glm_.*
+import java.io.*
+import java.nio.*
+import java.nio.file.*
+import java.io.IOException
+
+
+
+const val AI_MEMORYIO_MAGIC_FILENAME = "\$\$\$___magic___\$\$\$"
+const val AI_MEMORYIO_MAGIC_FILENAME_LENGTH = 17
+
+class MemoryIOSystem(val buffer: ByteBuffer) : IOSystem{
+
+	/** Tests for the existence of a file at the given path. */
+	override fun exists(pFile: String): Boolean = pFile.startsWith(AI_MEMORYIO_MAGIC_FILENAME)
+
+
+	override fun open(pFile: String): IOStream {
+
+		// TODO assimp originally returns null, but this would be against the current interface.
+		// I guess it should never happen anyways so an exception is fine
+		if(!pFile.startsWith(AI_MEMORYIO_MAGIC_FILENAME)) throw IOException("File does not exist! $pFile")
+
+		return MemoryIOStream(buffer, pFile)
+	}
+
+	class MemoryIOStream(val buffer: ByteBuffer, override val filename: String = "") : IOStream {
+
+		override val path: Path?
+			get() = null
+
+		override fun read(): InputStream {
+			return ByteBufferBackedInputStream(buffer)
+		}
+
+		override fun reader(): BufferedReader {
+			return BufferedReader(InputStreamReader(read()))
+		}
+
+		override fun parentPath(): String = ""
+	}
+}
+
+// TODO move this to a different file?
+private class ByteBufferBackedInputStream(val buf: ByteBuffer) : InputStream() {
+
+	/**
+	 * Reads the next byte of data from the input stream. The value byte is
+	 * returned as an <code>int</code> in the range <code>0</code> to
+	 * <code>255</code>. If no byte is available because the end of the stream
+	 * has been reached, the value <code>-1</code> is returned. This method
+	 * blocks until input data is available, the end of the stream is detected,
+	 * or an exception is thrown.
+	 *
+	 * <p> A subclass must provide an implementation of this method.
+	 *
+	 * @return     the next byte of data, or <code>-1</code> if the end of the
+	 *             stream is reached.
+	 * @exception  IOException  if an I/O error occurs.
+	 */
+	override fun read(): Int {
+		return if (!buf.hasRemaining()) {
+			-1
+		} else (buf.get() and 0xFF).toInt()
+	}
+
+	/**
+	 * Reads up to <code>len</code> bytes of data from the input stream into
+	 * an array of bytes.  An attempt is made to read as many as
+	 * <code>len</code> bytes, but a smaller number may be read.
+	 * The number of bytes actually read is returned as an integer.
+	 *
+	 * <p> This method blocks until input data is available, end of file is
+	 * detected, or an exception is thrown.
+	 *
+	 * <p> If <code>len</code> is zero, then no bytes are read and
+	 * <code>0</code> is returned; otherwise, there is an attempt to read at
+	 * least one byte. If no byte is available because the stream is at end of
+	 * file, the value <code>-1</code> is returned; otherwise, at least one
+	 * byte is read and stored into <code>b</code>.
+	 *
+	 * <p> The first byte read is stored into element <code>b[off]</code>, the
+	 * next one into <code>b[off+1]</code>, and so on. The number of bytes read
+	 * is, at most, equal to <code>len</code>. Let <i>k</i> be the number of
+	 * bytes actually read; these bytes will be stored in elements
+	 * <code>b[off]</code> through <code>b[off+</code><i>k</i><code>-1]</code>,
+	 * leaving elements <code>b[off+</code><i>k</i><code>]</code> through
+	 * <code>b[off+len-1]</code> unaffected.
+	 *
+	 * <p> In every case, elements <code>b[0]</code> through
+	 * <code>b[off]</code> and elements <code>b[off+len]</code> through
+	 * <code>b[b.length-1]</code> are unaffected.
+	 *
+	 * <p> The <code>read(b,</code> <code>off,</code> <code>len)</code> method
+	 * for class <code>InputStream</code> simply calls the method
+	 * <code>read()</code> repeatedly. If the first such call results in an
+	 * <code>IOException</code>, that exception is returned from the call to
+	 * the <code>read(b,</code> <code>off,</code> <code>len)</code> method.  If
+	 * any subsequent call to <code>read()</code> results in a
+	 * <code>IOException</code>, the exception is caught and treated as if it
+	 * were end of file; the bytes read up to that point are stored into
+	 * <code>b</code> and the number of bytes read before the exception
+	 * occurred is returned. The default implementation of this method blocks
+	 * until the requested amount of input data <code>len</code> has been read,
+	 * end of file is detected, or an exception is thrown. Subclasses are encouraged
+	 * to provide a more efficient implementation of this method.
+	 *
+	 * @param      b     the buffer into which the data is read.
+	 * @param      off   the start offset in array <code>b</code>
+	 *                   at which the data is written.
+	 * @param      len   the maximum number of bytes to read.
+	 * @return     the total number of bytes read into the buffer, or
+	 *             <code>-1</code> if there is no more data because the end of
+	 *             the stream has been reached.
+	 * @exception  IOException If the first byte cannot be read for any reason
+	 * other than end of file, or if the input stream has been closed, or if
+	 * some other I/O error occurs.
+	 * @exception  NullPointerException If <code>b</code> is <code>null</code>.
+	 * @exception  IndexOutOfBoundsException If <code>off</code> is negative,
+	 * <code>len</code> is negative, or <code>len</code> is greater than
+	 * <code>b.length - off</code>
+	 * @see        java.io.InputStream#read()
+	 */
+	override fun read(bytes: ByteArray, off: Int, len: Int): Int {
+		@Suppress("NAME_SHADOWING")
+		var len = len
+		if (!buf.hasRemaining()) {
+			return -1
+		}
+
+		len = Math.min(len, buf.remaining())
+		buf.get(bytes, off, len)
+		return len
+	}
+}

--- a/src/test/kotlin/X/BCN_Epileptic.kt
+++ b/src/test/kotlin/X/BCN_Epileptic.kt
@@ -1,7 +1,6 @@
 package X
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 
@@ -12,7 +11,7 @@ class BCN_Epileptic : StringSpec() {
         val BCN_Epileptic = "BCN_Epileptic.X"
 
         BCN_Epileptic {
-            with(Importer().readFile(getResource("$x/$BCN_Epileptic"))!!) {
+            Importer().testFile(getResource("$x/$BCN_Epileptic")) {
                 println("Node names: ")
                 printNodeNames(rootNode)
                 with(rootNode) {

--- a/src/test/kotlin/X/Testwuson.kt
+++ b/src/test/kotlin/X/Testwuson.kt
@@ -1,7 +1,6 @@
 package X
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 class Testwuson : StringSpec() {
@@ -9,7 +8,7 @@ class Testwuson : StringSpec() {
         val testwuson = "Testwuson.X"
 
         testwuson {
-            with(Importer().readFile(getResource("$x/$testwuson"))!!) {
+            Importer().testFile(getResource("$x/$testwuson")) {
                 with(rootNode) {
                     X.printNodeNames(rootNode)
                 }

--- a/src/test/kotlin/X/anim_test.kt
+++ b/src/test/kotlin/X/anim_test.kt
@@ -1,7 +1,6 @@
 package X
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 class anim_test : StringSpec() {
@@ -11,8 +10,8 @@ class anim_test : StringSpec() {
         val anim_test_a = "anim_test.assbin"
 
         anim_test {
-            with(Importer().readFile(getResource("$x/$anim_test"))!!) {
-//                val compare  = Importer().readFile(x_ass + anim_test_a)!!
+            Importer().testFile(getResource("$x/$anim_test")) {
+//                val compare  = Importer().testFile(x_ass + anim_test_a)!!
 //
 //                kotlin.io.println("Node names: ")
 //                X.printNodeNames(rootNode)

--- a/src/test/kotlin/X/kwxport_test_cubewithvcolors.kt
+++ b/src/test/kotlin/X/kwxport_test_cubewithvcolors.kt
@@ -1,14 +1,13 @@
 package X
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 class kwxport_test_cubewithvcolors : StringSpec() {
     init {
         val test = "kwxport_test_cubewithvcolors.x"
         test {
-            with(Importer().readFile(getResource("$x/$test"))!!) {
+            Importer().testFile(getResource("$x/$test")) {
                 printNodeNames(rootNode)
             }
         }

--- a/src/test/kotlin/X/mozd02x.kt
+++ b/src/test/kotlin/X/mozd02x.kt
@@ -1,7 +1,6 @@
 package X
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 
@@ -16,7 +15,7 @@ class mozd02x : StringSpec() {
         val mozd02x_a = "mozd02.assbin"
 
         mozd02x {
-            with(Importer().readFile(getResource("$x/$mozd02x"))!!) {
+            Importer().testFile(getResource("$x/$mozd02x")) {
                 printNodeNames(rootNode)
                 with(rootNode) {
 

--- a/src/test/kotlin/X/test.kt
+++ b/src/test/kotlin/X/test.kt
@@ -1,22 +1,20 @@
 package X
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
-import assimp.models
 
 class test : StringSpec() {
     init {
         val test = "test.x"
         test {
-            with(Importer().readFile(getResource("$x/$test"))!!) {
+            Importer().testFile(getResource("$x/$test")) {
                 printNodeNames(rootNode)
             }
         }
         val test_c = "test.assbin"
         test_c {
-//            val model2 = Importer().readFile(x_ass + "test.assbin")!!
-//            val model1 = Importer().readFile(x + "test.x")!!
+//            val model2 = Importer().testFile(x_ass + "test.assbin")
+//            val model1 = Importer().testFile(x + "test.x")!!
 //
 //            compareScenes(model1, model2)
         }

--- a/src/test/kotlin/X/test_cube_text.kt
+++ b/src/test/kotlin/X/test_cube_text.kt
@@ -1,14 +1,13 @@
 package X
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 class test_cube_text : StringSpec() {
     init {
         val test = "test_cube_text.x"
         test {
-            with(Importer().readFile(getResource("$x/$test"))!!) {
+            Importer().testFile(getResource("$x/$test")) {
                 printNodeNames(rootNode)
             }
         }

--- a/src/test/kotlin/assimp/assbin/assbin.kt
+++ b/src/test/kotlin/assimp/assbin/assbin.kt
@@ -1,8 +1,6 @@
 package assimp.assbin
 
-import assimp.Importer
-import assimp.getResource
-import assimp.models
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 class assbin : StringSpec() {
@@ -15,7 +13,7 @@ class assbin : StringSpec() {
 //
 //        anims_with_full_rotations_between_keys {
 //
-//            val scene = Importer().readFile(assbin + anims_with_full_rotations_between_keys)!!
+//            val scene = Importer().testFile(assbin + anims_with_full_rotations_between_keys)!!
 //            println()
 ////            scene.flags shouldBe 0
 //        }
@@ -24,7 +22,7 @@ class assbin : StringSpec() {
 
         boblampclean {
 
-            val scene = Importer().readFile(getResource("$assbin/$boblampclean"))
+            val scene = Importer().testFile(getResource("$assbin/$boblampclean"))
 
             println()
         }
@@ -33,7 +31,7 @@ class assbin : StringSpec() {
 
         minigun {
 
-            val scene = Importer().readFile(getResource("$assbin/$minigun"))
+            val scene = Importer().testFile(getResource("$assbin/$minigun"))
 
             println()
         }

--- a/src/test/kotlin/assimp/assbin/boblampclean_assbin.kt
+++ b/src/test/kotlin/assimp/assbin/boblampclean_assbin.kt
@@ -1,8 +1,6 @@
 package assimp.assbin
 
-import assimp.Importer
-import assimp.assbin
-import assimp.getResource
+import assimp.*
 import io.kotlintest.specs.StringSpec
 
 // TODO
@@ -25,7 +23,7 @@ class `boblampclean assbin` : StringSpec() {
 
         boblampclean {
 
-            val scene = Importer().readFile(getResource("$assbin/$boblampclean"))
+            val scene = Importer().testFile(getResource("$assbin/$boblampclean"))
 
             println()
         }
@@ -34,7 +32,7 @@ class `boblampclean assbin` : StringSpec() {
 
         minigun {
 
-            val scene = Importer().readFile(getResource("$assbin/$minigun"))
+            val scene = Importer().testFile(getResource("$assbin/$minigun"))
 
             println()
         }

--- a/src/test/kotlin/assimp/assxml/anim_test.kt
+++ b/src/test/kotlin/assimp/assxml/anim_test.kt
@@ -1,11 +1,10 @@
 package assimp.assxml
 
 import X.x
-import assimp.Importer
+import assimp.*
 import assimp.format.X.FlipWindingOrderProcess
 import assimp.format.X.MakeLeftHandedProcess
 import assimp.format.assxml.AssxmlExporter
-import assimp.getResource
 import io.kotlintest.specs.StringSpec
 import java.util.*
 
@@ -13,12 +12,13 @@ class anim_test : StringSpec() {
     init {
         val test1 = "anim_test.X -> anim_test.assxml"
         test1 {
-            Importer().readFile(getResource("$x/anim_test.x"))!!.let { f1 ->
-                FlipWindingOrderProcess.Execute(f1)
-                MakeLeftHandedProcess.Execute(f1) // TODO switch to flag
+            Importer().testFile(getResource("$x/anim_test.x")) {
+
+                FlipWindingOrderProcess.Execute(this)
+                MakeLeftHandedProcess.Execute(this) // TODO switch to flag
 
                 StringBuilder().let { out ->
-                    AssxmlExporter().ExportSceneAssxml(out, f1)
+                    AssxmlExporter().ExportSceneAssxml(out, this)
                     println(out.toString())
                     println("succesful")
                 }

--- a/src/test/kotlin/assimp/assxml/test.kt
+++ b/src/test/kotlin/assimp/assxml/test.kt
@@ -1,9 +1,8 @@
 package assimp.assxml
 
 import X.x
-import assimp.Importer
+import assimp.*
 import assimp.format.assxml.AssxmlExporter
-import assimp.getResource
 import io.kotlintest.specs.StringSpec
 import java.util.*
 
@@ -11,9 +10,9 @@ class test : StringSpec() {
     init {
         val test1 = "test.x -> test.assxml"
         test1 {
-            Importer().readFile(getResource("$x/test.x"))!!.let { f1 ->
+            Importer().testFile(getResource("$x/test.x")) {
                 StringBuilder().let { out ->
-                    AssxmlExporter().ExportSceneAssxml(out, f1)
+                    AssxmlExporter().ExportSceneAssxml(out, this)
                     println()
                     println()
                     println()

--- a/src/test/kotlin/assimp/blender/blenderDefault_250_compressed.kt
+++ b/src/test/kotlin/assimp/blender/blenderDefault_250_compressed.kt
@@ -1,9 +1,6 @@
 package assimp.blender
 
-import assimp.AI_DEFAULT_MATERIAL_NAME
-import assimp.AiPrimitiveType
-import assimp.AiShadingMode
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -18,7 +15,7 @@ object blenderDefault_250_compressed {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(fileName)!!) {
+        Importer().testFile(fileName) {
 
 //            flags shouldBe 0
 //

--- a/src/test/kotlin/assimp/collada/animFullRot.kt
+++ b/src/test/kotlin/assimp/collada/animFullRot.kt
@@ -1,7 +1,6 @@
 package assimp.collada
 
-import assimp.AiAnimBehaviour
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.quat.Quat
 import glm_.vec3.Vec3
@@ -12,7 +11,7 @@ object animFullRot {
 
     operator fun invoke(url: URL) {
 
-        with(Importer().readFile(url)!!) {
+        Importer().testFile(url) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/collada/cameras.kt
+++ b/src/test/kotlin/assimp/collada/cameras.kt
@@ -1,6 +1,6 @@
 package assimp.collada
 
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -10,7 +10,7 @@ object cameras {
 
     operator fun invoke(fileName: URL) {
 
-        with(Importer().readFile(fileName)!!) {
+        Importer().testFile(fileName) {
 
             flags shouldBe 1
             with(rootNode) {

--- a/src/test/kotlin/assimp/collada/color teapot spheres.kt
+++ b/src/test/kotlin/assimp/collada/color teapot spheres.kt
@@ -1,8 +1,6 @@
 package assimp.collada
 
-import assimp.AiPostProcessStep
-import assimp.AiPrimitiveType
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.matchers.shouldBe
@@ -12,7 +10,7 @@ object `color teapot spheres` {
 
     operator fun invoke(fileName: URL) {
 
-        with(Importer().readFile(fileName)!!) {
+        Importer().testFile(fileName){
 
             flags shouldBe 0
             with(rootNode) {

--- a/src/test/kotlin/assimp/collada/concavePoly.kt
+++ b/src/test/kotlin/assimp/collada/concavePoly.kt
@@ -1,7 +1,6 @@
 package assimp.collada
 
-import assimp.AiShadingMode
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -11,7 +10,7 @@ object concavePoly {
 
     operator fun invoke(fileName: URL) {
 
-        with(Importer().readFile(fileName)!!) {
+        Importer().testFile(fileName) {
 
             flags shouldBe 0
             with(rootNode) {

--- a/src/test/kotlin/assimp/collada/treasure_smooth Pretransform.kt
+++ b/src/test/kotlin/assimp/collada/treasure_smooth Pretransform.kt
@@ -1,8 +1,6 @@
 package assimp.collada
 
-import assimp.AiPostProcessStep
-import assimp.AiPrimitiveType
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.matchers.shouldBe
@@ -12,7 +10,7 @@ object `treasure_smooth Pretransform` {
 
     operator fun invoke(fileName: URL) {
 
-        with(Importer().readFile(fileName, AiPostProcessStep.PreTransformVertices.i)!!) {
+        Importer().testFile(fileName, AiPostProcessStep.PreTransformVertices.i){
 
             flags shouldBe 0
             with(rootNode) {

--- a/src/test/kotlin/assimp/collada/treasure_smooth.kt
+++ b/src/test/kotlin/assimp/collada/treasure_smooth.kt
@@ -1,8 +1,6 @@
 package assimp.collada
 
-import assimp.AiPostProcessStep
-import assimp.AiPrimitiveType
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.matchers.shouldBe
@@ -12,7 +10,7 @@ object treasure_smooth {
 
     operator fun invoke(fileName: URL) {
 
-        with(Importer().readFile(fileName)!!) {
+        Importer().testFile(fileName){
 
             flags shouldBe 0
             with(rootNode) {

--- a/src/test/kotlin/assimp/collada/voyager.kt
+++ b/src/test/kotlin/assimp/collada/voyager.kt
@@ -1,7 +1,6 @@
 package assimp.collada
 
-import assimp.AiAnimBehaviour
-import assimp.Importer
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.quat.Quat
 import glm_.vec3.Vec3
@@ -12,7 +11,7 @@ object voyager {
 
     operator fun invoke(url: URL) {
 
-        with(Importer().readFile(url)!!) {
+        Importer().testFile(url) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/fbx/animFullRot.kt
+++ b/src/test/kotlin/assimp/fbx/animFullRot.kt
@@ -1,7 +1,6 @@
 package assimp.fbx
 
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -10,7 +9,7 @@ object animFullRot {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/fbx/concavePolygon.kt
+++ b/src/test/kotlin/assimp/fbx/concavePolygon.kt
@@ -1,8 +1,6 @@
 package assimp.fbx
 
-import assimp.AiVector3D
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -11,7 +9,7 @@ object concavePolygon {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/md2/faerie.kt
+++ b/src/test/kotlin/assimp/md2/faerie.kt
@@ -1,9 +1,6 @@
 package assimp.md2
 
-import assimp.AiShadingMode
-import assimp.AiTexture
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -12,7 +9,7 @@ object faerie {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)){
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/md3/europeanFnt.kt
+++ b/src/test/kotlin/assimp/md3/europeanFnt.kt
@@ -9,7 +9,7 @@ object europeanFnt {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/md3/watercan.kt
+++ b/src/test/kotlin/assimp/md3/watercan.kt
@@ -1,9 +1,6 @@
 package assimp.md3
 
-import assimp.AiShadingMode
-import assimp.AiTexture
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -12,7 +9,7 @@ object watercan {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/md5/boarMan.kt
+++ b/src/test/kotlin/assimp/md5/boarMan.kt
@@ -1,9 +1,6 @@
 package assimp.md5
 
-import assimp.AiShadingMode
-import assimp.AiTexture
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -12,7 +9,7 @@ object boarMan {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 
@@ -77,7 +74,7 @@ object boarMan {
                 textureCoords[0][8435][0] shouldBe 0.303604007f
                 textureCoords[0][8435][1] shouldBe 1.94788897f
 
-                faces.asSequence().filterIndexed { i, f -> i in 0..7 }.forEachIndexed { i, f ->
+                faces.asSequence().filterIndexed { i, _ -> i in 0..7 }.forEachIndexed { i, f ->
                     val idx = i * 3
                     f shouldBe mutableListOf(idx + 1, idx + 2, idx)
                 }

--- a/src/test/kotlin/assimp/md5/simpleCube.kt
+++ b/src/test/kotlin/assimp/md5/simpleCube.kt
@@ -1,9 +1,6 @@
 package assimp.md5
 
-import assimp.AiShadingMode
-import assimp.AiTexture
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -12,7 +9,7 @@ object simpleCube {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/obj/box.kt
+++ b/src/test/kotlin/assimp/obj/box.kt
@@ -15,7 +15,7 @@ object box {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             with(rootNode) {
 

--- a/src/test/kotlin/assimp/obj/cube.kt
+++ b/src/test/kotlin/assimp/obj/cube.kt
@@ -15,7 +15,7 @@ object cube {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             //            with(rootNode) {
 //

--- a/src/test/kotlin/assimp/obj/dragon.kt
+++ b/src/test/kotlin/assimp/obj/dragon.kt
@@ -1,13 +1,13 @@
 package assimp.obj
 
-import assimp.Importer
+import assimp.*
 
 // TODO
 object dragon {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(fileName)!!) {
+        Importer().testFile(fileName) {
 
             with(rootNode) {
 

--- a/src/test/kotlin/assimp/obj/nanosuit.kt
+++ b/src/test/kotlin/assimp/obj/nanosuit.kt
@@ -9,7 +9,7 @@ import java.util.*
 object nanosuit {
 
     operator fun invoke(fileName: String) {
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             with(rootNode) {
 

--- a/src/test/kotlin/assimp/obj/shelter.kt
+++ b/src/test/kotlin/assimp/obj/shelter.kt
@@ -15,7 +15,7 @@ object shelter {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             with(rootNode) {
 

--- a/src/test/kotlin/assimp/obj/spider.kt
+++ b/src/test/kotlin/assimp/obj/spider.kt
@@ -1,9 +1,6 @@
 package assimp.obj
 
-import assimp.AiPrimitiveType
-import assimp.AiShadingMode
-import assimp.Importer
-import assimp.getResource
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -13,7 +10,7 @@ object spider {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)){
 
             with(rootNode) {
 

--- a/src/test/kotlin/assimp/obj/wall.kt
+++ b/src/test/kotlin/assimp/obj/wall.kt
@@ -9,7 +9,7 @@ object wall {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
             println()
 //            with(rootNode) {
 //

--- a/src/test/kotlin/assimp/ply/cube.kt
+++ b/src/test/kotlin/assimp/ply/cube.kt
@@ -9,7 +9,7 @@ import java.util.*
 object cube {
 
     operator fun invoke(fileName: String) {
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             numMeshes shouldBe 1
             with(meshes[0]) {

--- a/src/test/kotlin/assimp/ply/pond0.kt
+++ b/src/test/kotlin/assimp/ply/pond0.kt
@@ -10,7 +10,7 @@ object pond0 {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)){
 
             numMeshes shouldBe 1
             with(meshes[0]) {

--- a/src/test/kotlin/assimp/ply/wuson.kt
+++ b/src/test/kotlin/assimp/ply/wuson.kt
@@ -9,7 +9,7 @@ import java.util.*
 object wuson {
 
     operator fun invoke(fileName: String) {
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             numMeshes shouldBe 1
             with(meshes[0]) {

--- a/src/test/kotlin/assimp/stl/sphereWithHole.kt
+++ b/src/test/kotlin/assimp/stl/sphereWithHole.kt
@@ -1,9 +1,6 @@
 package assimp.stl
 
-import assimp.AiPrimitiveType
-import assimp.Importer
-import assimp.getResource
-import assimp.models
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -13,7 +10,7 @@ object sphereWithHole {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/stl/spiderBinary.kt
+++ b/src/test/kotlin/assimp/stl/spiderBinary.kt
@@ -1,9 +1,6 @@
 package assimp.stl
 
-import assimp.AiPrimitiveType
-import assimp.Importer
-import assimp.getResource
-import assimp.models
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -13,7 +10,7 @@ object spiderBinary {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 

--- a/src/test/kotlin/assimp/stl/triangle.kt
+++ b/src/test/kotlin/assimp/stl/triangle.kt
@@ -1,9 +1,6 @@
 package assimp.stl
 
-import assimp.AiPrimitiveType
-import assimp.Importer
-import assimp.getResource
-import assimp.models
+import assimp.*
 import glm_.mat4x4.Mat4
 import glm_.vec3.Vec3
 import io.kotlintest.shouldBe
@@ -13,7 +10,7 @@ object triangle {
 
     operator fun invoke(fileName: String) {
 
-        with(Importer().readFile(getResource(fileName))!!) {
+        Importer().testFile(getResource(fileName)) {
 
             flags shouldBe 0
 


### PR DESCRIPTION
In MemoryIOWrapper I added 2 TODOs. One is about the return value of `open`. The c implementation of assimp returns null, but the kotlin interface is defined as not null. I think it is ok to throw in this case, but I wasn't 100% sure so I added the TODO. Feel free to remove it.

I also had to implement an `InputStream` backed by a `ByteBuffer`. I did not find any implementations out there in any accessible lib so I just chose one from stackoverflow (I sadly forgot to write down the link). As far as I know it is correct.

Oh and I fixed a bug in the build file stoping the tests from being executed 😜 