### PR TITLE
Collada bug

### DIFF
--- a/src/main/kotlin/assimp/BaseImporter.kt
+++ b/src/main/kotlin/assimp/BaseImporter.kt
@@ -63,6 +63,7 @@ abstract class BaseImporter {
         } catch (err: Exception) {
             // extract error description
             logger.error(err) {}
+            errorText = err.localizedMessage
             return null
         }
         // return what we gathered from the import.

--- a/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaLoader.kt
@@ -644,9 +644,8 @@ class ColladaLoader : BaseImporter() {
         // for some exporters, but we won't care of it unless someone complains about.
         tex.uvwsrc = when {
             sampler.mUVId != Uint.MAX_VALUE.i -> sampler.mUVId // TODO MAX_VALUE to Int
-            else -> sampler.mUVChannel.firstOrNull(Char::isNumeric)?.let {
+            else -> sampler.mUVChannel.firstOrNull(Char::isNumeric)?.minus('0') ?: 0.also {
                 logger.warn { "Collada: unable to determine UV channel for texture" }
-                0
             }
         }
 

--- a/src/main/kotlin/assimp/format/collada/ColladaParser.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaParser.kt
@@ -122,7 +122,12 @@ class ColladaParser(pFile: IOStream) {
         reader = factory.createXMLEventReader(pFile.reader())
 
         // start reading
-        readContents()
+        try {
+            readContents()
+        } catch (e: Exception) {
+            error("Collada parse error at line ${event.location.lineNumber}, column ${event.location.columnNumber}, in \"${pFile.path}\"")
+        }
+
     }
 
     /** Read bool from text contents of current element */

--- a/src/main/kotlin/assimp/format/collada/ColladaParser.kt
+++ b/src/main/kotlin/assimp/format/collada/ColladaParser.kt
@@ -602,9 +602,8 @@ class ColladaParser(pFile: IOStream) {
                     mMaterialLibrary[id] = Material()   // create an entry and store it in the library under its ID
                     if (name.isNotEmpty()) {
                         if (names.contains(name)) {
-                            val nextId = names.keys.sorted().indexOf(name) + 1
-                            val nextName = names.keys.sorted()[nextId]
-                            name += " " + names[nextName]
+                            names[name] = 1 + names[name]!!
+                            name += " " + names[name]
                         } else names[name] = 0
                         mMaterialLibrary[id]!!.mName = name
                     }


### PR DESCRIPTION
As a newbie to Kotlin, kotlin-graphics/assimp, and Assimp in general, any guidance on what is needed, how things are done, is appreciated.

commit 301d1ae014c7263db1f911285cf130f624d3acc3
    Repair readMaterialLibrary's handling of duplicate names.
        The native Assimp's ColladaParser::ReadMaterialLibrary has, to my mind, an excessive use of high power machinery obscuring both the intent and the actual action.  The initial translation to Kotlin missed a bit of syntactic cleverness, resulting in an array bounds exception.  If three Collada <material> elements have name="Mary", the action is to name the material library entries "Mary, "Mary 1", and "Mary 2".
        Test by manually editing a Collada .dae file and just duplicate one of the
<material> elements.

commit 15bae1130907d04ca2cc145beca5a01db89c9153
    Repair fallback texture CHANNEL guess.
        This failure was exposed by a Collada file that actually fell to this fallback calculation of the texture channel number.  But the coding resulted in the ASCII code for
'0'.

commit 2ff8c8532093cd0caaf85865c5e9a7cfea4442bb
    Propagate Collada import failure info through to user as importer.errorString.
        The exception thrown because of a duplicate <material> resulted in readFile returning scene=null, but then getErrorString() returned "", and calling from Java invoked under NetBeans, the traceback did not appear anywhere obvious.  Even though that exception is now quieted, tracking it down revealed that any unexpected exception in the Collada loader would be caught in BaseImporter where the exception's message was passed to the logger but not copied through to Importer.errorString where the user could get it.
        My solution is to catch unexpected exceptions in the Collada loader and pass on a message that at least indicates where in the input the problem occurred, and then to put the resulting message where it gets copied to where the user expects a problem report.  Checking other exceptions, from Collada loader or elsewhere, seems futile, not not on board with the directive to to the right thing with correct input and spend no significant effort on verifying compliance of the input data.
